### PR TITLE
DefineProperty method

### DIFF
--- a/quickjs.go
+++ b/quickjs.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"math/big"
-	"strconv"
 	"unsafe"
 )
 
@@ -701,11 +700,7 @@ func (v Value) PropertyNames() ([]PropertyEnum, error) {
 	return names, nil
 }
 
-func PropertyOption(s string) *bool {
-	b, err := strconv.ParseBool(s)
-	if err != nil {
-		return nil
-	}
+func PropertyOption(b bool) *bool {
 	return &b
 }
 

--- a/quickjs.go
+++ b/quickjs.go
@@ -710,7 +710,6 @@ func PropertyOption(s string) *bool {
 }
 
 type PropertyDescriptor struct {
-	Name           string
 	IsConfigurable *bool
 	IsEnumerable   *bool
 
@@ -723,11 +722,11 @@ type PropertyDescriptor struct {
 	Setter *Value
 }
 
-func (v Value) DefineProperty(desc PropertyDescriptor) error {
+func (v Value) DefineProperty(name string, desc PropertyDescriptor) error {
 
 	// common
-	if desc.Name == "" {
-		return errors.New("desc must have a name")
+	if name == "" {
+		return errors.New("property must have a name")
 	}
 
 	// data or accessor descriptor ?
@@ -790,7 +789,7 @@ func (v Value) DefineProperty(desc PropertyDescriptor) error {
 		}
 	}
 
-	atom := v.ctx.Atom(desc.Name)
+	atom := v.ctx.Atom(name)
 	result := int(C.JS_DefineProperty(v.ctx.ref, v.ref, atom.ref, value, getter, setter, C.int(flags)))
 	if result < 0 {
 		return errors.New("error defining the property descriptor")

--- a/quickjs_test.go
+++ b/quickjs_test.go
@@ -205,8 +205,8 @@ func TestDefineProperty(t *testing.T) {
 	propName = "val"
 	value := context.String(propValue)
 	prop = PropertyDescriptor{
-		IsConfigurable: PropertyOption("false"),
-		IsEnumerable:   PropertyOption("false"),
+		IsConfigurable: PropertyOption(false),
+		IsEnumerable:   PropertyOption(false),
 		Value:          &value,
 	}
 	checkProperty(t, context, jsObj, prop, propName, propValue, "obj.%s === '%s'")
@@ -219,8 +219,8 @@ func TestDefineProperty(t *testing.T) {
 		return context.DupValue(val)
 	})
 	prop = PropertyDescriptor{
-		IsConfigurable: PropertyOption("false"),
-		IsEnumerable:   PropertyOption("false"),
+		IsConfigurable: PropertyOption(false),
+		IsEnumerable:   PropertyOption(false),
 		Setter:         &setter,
 	}
 	checkProperty(t, context, jsObj, prop, propName, propValue, "obj.%s = '%s'")
@@ -231,8 +231,8 @@ func TestDefineProperty(t *testing.T) {
 		return context.String(goObj.val)
 	})
 	prop = PropertyDescriptor{
-		IsConfigurable: PropertyOption("false"),
-		IsEnumerable:   PropertyOption("false"),
+		IsConfigurable: PropertyOption(false),
+		IsEnumerable:   PropertyOption(false),
 		Getter:         &getter,
 	}
 	checkProperty(t, context, jsObj, prop, propName, propValue, "obj.%s === '%s'")

--- a/quickjs_test.go
+++ b/quickjs_test.go
@@ -167,8 +167,8 @@ func TestMemoryLimit(t *testing.T) {
 	result.Free()
 }
 
-func checkProperty(t *testing.T, ctx *Context, obj Value, prop Property, propName, propValue, code string) {
-	err := obj.DefineProperty(prop)
+func checkProperty(t *testing.T, ctx *Context, obj Value, desc PropertyDescriptor, propName, propValue, code string) {
+	err := obj.DefineProperty(desc)
 	require.NoErrorf(t, err, "define property '%s'", propName)
 	result, err := ctx.Eval(fmt.Sprintf(code, propName, propValue), EVAL_GLOBAL)
 	assert.NoError(t, err)
@@ -196,7 +196,7 @@ func TestDefineProperty(t *testing.T) {
 	context.Globals().Set("obj", jsObj)
 
 	var (
-		prop      Property
+		prop      PropertyDescriptor
 		propName  string
 		propValue = "ok"
 	)
@@ -204,7 +204,7 @@ func TestDefineProperty(t *testing.T) {
 	// data
 	propName = "val"
 	value := context.String(propValue)
-	prop = Property{
+	prop = PropertyDescriptor{
 		Name:           propName,
 		IsConfigurable: PropertyOption("false"),
 		IsEnumerable:   PropertyOption("false"),
@@ -219,7 +219,7 @@ func TestDefineProperty(t *testing.T) {
 		goObj.val = val.String()
 		return context.DupValue(val)
 	})
-	prop = Property{
+	prop = PropertyDescriptor{
 		Name:           propName,
 		IsConfigurable: PropertyOption("false"),
 		IsEnumerable:   PropertyOption("false"),
@@ -232,7 +232,7 @@ func TestDefineProperty(t *testing.T) {
 	getter := context.Function(func(ctx *Context, this Value, args []Value) Value {
 		return context.String(goObj.val)
 	})
-	prop = Property{
+	prop = PropertyDescriptor{
 		Name:           propName,
 		IsConfigurable: PropertyOption("false"),
 		IsEnumerable:   PropertyOption("false"),

--- a/quickjs_test.go
+++ b/quickjs_test.go
@@ -168,7 +168,7 @@ func TestMemoryLimit(t *testing.T) {
 }
 
 func checkProperty(t *testing.T, ctx *Context, obj Value, desc PropertyDescriptor, propName, propValue, code string) {
-	err := obj.DefineProperty(desc)
+	err := obj.DefineProperty(propName, desc)
 	require.NoErrorf(t, err, "define property '%s'", propName)
 	result, err := ctx.Eval(fmt.Sprintf(code, propName, propValue), EVAL_GLOBAL)
 	assert.NoError(t, err)
@@ -205,7 +205,6 @@ func TestDefineProperty(t *testing.T) {
 	propName = "val"
 	value := context.String(propValue)
 	prop = PropertyDescriptor{
-		Name:           propName,
 		IsConfigurable: PropertyOption("false"),
 		IsEnumerable:   PropertyOption("false"),
 		Value:          &value,
@@ -220,7 +219,6 @@ func TestDefineProperty(t *testing.T) {
 		return context.DupValue(val)
 	})
 	prop = PropertyDescriptor{
-		Name:           propName,
 		IsConfigurable: PropertyOption("false"),
 		IsEnumerable:   PropertyOption("false"),
 		Setter:         &setter,
@@ -233,7 +231,6 @@ func TestDefineProperty(t *testing.T) {
 		return context.String(goObj.val)
 	})
 	prop = PropertyDescriptor{
-		Name:           propName,
 		IsConfigurable: PropertyOption("false"),
 		IsEnumerable:   PropertyOption("false"),
 		Getter:         &getter,


### PR DESCRIPTION
Hi,

I have added a `func (v Value) DefineProperty` method to call `C.JS_DefineProperty` function.

The `PropertyDescriptor` struct follows the [standard](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty) defined in JS by `Object.defineProperty`.